### PR TITLE
Use app's routing system for URLs

### DIFF
--- a/src/components/QuantumLandscapeChart.js
+++ b/src/components/QuantumLandscapeChart.js
@@ -350,7 +350,7 @@ function scatterplot (
     .on('click', function () {
       if (!isMobile) {
         const submissionId = d3.select(this).attr('submission_id')
-        window.open(`https://metriq.info/Submission/${submissionId}`)
+        window.open(`/Submission/${submissionId}`)
       }
     })
     .on('mousemove touchstart', (e) =>
@@ -476,7 +476,7 @@ function mousemove (
         <div style="font-size: 1.5em;">${idData.task_name}</div>
         ${idData.reference}<br>
         ${idData.year}<br>
-        <a href="https://metriq.info/Submission/${
+        <a href="/Submission/${
           idData.submission_id
         }" style="color: ${
         colors[domainIndex[idData.domain]]

--- a/src/components/QuantumVolumeChart.js
+++ b/src/components/QuantumVolumeChart.js
@@ -398,7 +398,7 @@ function QuantumVolumeChart (props) {
           : ('<div style="font-size: 1.5em;">' + (idData.platformName ? idData.platformName : idData.methodName) + '</div>')}
         ${d3.utcFormat('%B %d, %Y')(idData.tableDate)}<br>
         ${!otherCircles && !idData.platformName ? '' : (idData.methodName + '<br>')}
-        <a href="https://metriq.info/Submission/${
+        <a href="/Submission/${
           idData.submissionId
         }" style="color: ${
           colors[props.isQubits ? idData.qubitCount - 1 : domainIndex[idData.domain]]
@@ -704,7 +704,7 @@ function QuantumVolumeChart (props) {
       .on('click', function () {
         if (!isMobile) {
           const submissionId = d3.select(this).attr('submissionId')
-          window.open(`https://metriq.info/Submission/${submissionId}`)
+          window.open(`/Submission/${submissionId}`)
         }
       })
       .on('mousemove touchstart', (e) =>


### PR DESCRIPTION
Replaces hardcoded external URLs with relative internal URLs. 
Currently, when running it locally, those links bring the page out of the localhost environment. 
This change also adds the flexibility of deploying Metriq to a different domain. 

## Testing
Tested by clicking on the dots of the QV chart on the Trends page
