### PR TITLE
Remove autofilling of submission thumbnail url

### DIFF
--- a/src/views/AddSubmission.js
+++ b/src/views/AddSubmission.js
@@ -149,15 +149,6 @@ class AddSubmission extends React.Component {
         .catch(err => {
           this.setState({ requestFailedMessage: ErrorHandler(err) })
         })
-    } else if (field === 'thumbnailUrl') {
-      axios.post(config.api.getUriPrefix() + '/pagemetadata', { url: value.trim() })
-        .then(res => {
-          const images = res.data.data.images
-          this.setState({ thumbnailUrl: images[images.length - 1].src, isValidated: false })
-        })
-        .catch(err => {
-          this.setState({ requestFailedMessage: ErrorHandler(err) })
-        })
     }
   }
 


### PR DESCRIPTION
It's a complementary PR to https://github.com/unitaryfoundation/metriq-api/pull/237
The new library used to parse html metadata doesn't fetch images url from the page. Not an important feature imho, and we can re-add it in the future. 
