### PR TITLE
fix: Fixing y-axis legend numbering for d3

### DIFF
--- a/src/components/QuantumVolumeChart.js
+++ b/src/components/QuantumVolumeChart.js
@@ -593,7 +593,8 @@ function QuantumVolumeChart (props) {
           .attr('text-anchor', 'end')
           .text(xAxisText)
       )
-    const yAxis = isl ? d3.axisLeft(yScale).tickFormat(d3.format('~s')) : d3.axisLeft(yScale)
+    const yAxis = d3.axisLeft(yScale).tickFormat(d3.format('.2f'))
+
     // append y axis
     svg
       .append('g')


### PR DESCRIPTION
Axis labelling fixed/adapted from 

<img width="54" alt="Screenshot 2025-05-06 at 6 27 59 PM" src="https://github.com/user-attachments/assets/f9bee55e-cb85-4dff-afb6-2d4bf6e1b5d1" />

to:

<img width="56" alt="Screenshot 2025-05-06 at 6 26 09 PM" src="https://github.com/user-attachments/assets/f3ec25fb-3b86-4add-9ab6-10e0e89cec34" />