### PR TITLE
fix: hover label for axis is now properly formatted.

### DIFF
--- a/src/components/QuantumVolumeChart.js
+++ b/src/components/QuantumVolumeChart.js
@@ -984,7 +984,7 @@ function QuantumVolumeChart (props) {
       .style('visibility', 'hidden')
       .style('font-size', `${smallLabelSize}px`)
       .style('font-family', fontType)
-      .text((i) => d3.format('.2s')(y(i)))
+      .text((i) => d3.format('.2f')(y(i)))
 
     if (isSameDate) {
       barplot(


### PR DESCRIPTION
Closes: #993 

Fixes the hover Y-axis label

<img width="324" alt="Screenshot 2025-05-22 at 6 09 55 PM" src="https://github.com/user-attachments/assets/5c5c42ba-e13c-4616-a6a2-bb06c8d35b45" />
