### PR TITLE
feat: added box plot as a Chart type

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
     "chart.js": "3.8.0",
     "chartjs-adapter-moment": "^1.0.0",
+    "chartjs-chart-box-and-violin-plot": "^4.0.0",
     "chartjs-chart-error-bars": "3.8.0",
     "chartjs-plugin-annotation": "^2.2.1",
     "chartjs-plugin-datalabels": "^2.2.0",


### PR DESCRIPTION
This PR modifies the existing Chart.js setup and extends it to support box plots as an alternative visualization option. Users can now toggle between the default chart type and box plots to better visualize data distribution.

![image](https://github.com/user-attachments/assets/aa609f59-4bc7-467d-b7b1-777bae7a1e51)

![image](https://github.com/user-attachments/assets/3c331444-e45d-4559-9e5d-e36460390dac)


Fixes #862 