### PR TITLE
chore: removed logical vs. physical qubit results from progress chart

### DIFF
--- a/src/progress.csv
+++ b/src/progress.csv
@@ -25,5 +25,4 @@ Quantum resource estimates for computing binary elliptic curve discrete logarith
 Quantum resource estimates for computing binary elliptic curve discrete logarithms,arXiv:2503.02984,2025,Cryptography,ECC-233,228,829,3035,3520000,false,Both
 Fast quantum simulation of electronic structure by spectrum amplification,arXiv:2502.15882,2025,Physics simulation,FeMoco-54,228,830,1137,341000000,false,Both
 Fast quantum simulation of electronic structure by spectrum amplification,arXiv:2502.15882,2025,Physics simulation,FeMoco-76,228,830,1459,999000000,false,Both
-How to factor 2048 bit RSA integers with less than a million noisy qubits,arXiv:2505.15917,2025,Cryptography,Factoring,0,840,897864,10000000000,false,Both
-How to factor 2048 bit RSA integers in 8 hours using 20 million noisy qubits,"Quantum 5, 433 (2021) volume5, page 433",2021,Cryptography,Factoring,0,761,20000000,2700000000,false,Both
+


### PR DESCRIPTION
- Removed two recently added results for the progress chart that were keyed in using physical quibts (instead of logical qubits). 

Reverting #1007 