### PR TITLE
Unhide metriq-gym table on trends page

### DIFF
--- a/src/views/Trends.js
+++ b/src/views/Trends.js
@@ -138,6 +138,13 @@ class Trends extends React.Component {
               )}
             </div>
           </div>
+          <div className='row'>
+            <div className='col'>
+              <h4 align='left'><a href={`/submission/${METRIQ_GYM_SUBMISSION_ID}`}>Metriq-gym results</a></h4>
+              <br />
+              <AggregatedMetricsTable results={this.state.results} />
+            </div>
+          </div>
           <br />
           <FormFieldAlertRow>
             <FormFieldValidator invalid={!!this.state.requestFailedMessage} message={this.state.requestFailedMessage} />


### PR DESCRIPTION
Showing again the table from #982 (hidden in #1003), now that we are confident on results in the metriq-gym submission. 