### PR TITLE
New metriq-gym tab in navigation bar 

### DIFF
--- a/src/MainRouter.js
+++ b/src/MainRouter.js
@@ -36,6 +36,7 @@ import Qedc from './views/Qedc'
 import Vqa from './views/Vqa'
 import Progress from './views/Progress'
 import Sota from './views/Sota'
+import MetriqGym from './views/MetriqGym'
 
 const MainRouter = (props) => {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
@@ -313,6 +314,11 @@ const MainRouter = (props) => {
           exact
           path='/Provider/:id'
           render={(p) => <Platforms {...p} isDataSet={false} isLoggedIn={isLoggedIn} onLogin={handleLogin} isProvider key={Math.random()} />}
+        />
+        <Route
+          exact
+          path='/MetriqGym'
+          component={MetriqGym}
         />
         <Route component={NotFound} />
       </Switch>

--- a/src/components/MainNavLeft.js
+++ b/src/components/MainNavLeft.js
@@ -14,7 +14,15 @@ const MainNavLeft = () => {
       <Nav.Link as={NavLink} activeClassName='active-navlink' to='/Trends' className='metriq-navbar-text' eventKey='5' isActive={(match, location) => (location.pathname === '/Trends' || location.pathname === '/')}>Trends</Nav.Link>
       <Nav.Link as={NavLink} activeClassName='active-navlink' to='/Progress' className='metriq-navbar-text' eventKey='6'>Progress</Nav.Link>
       <Nav.Link as={NavLink} activeClassName='active-navlink' to='/Data' className='metriq-navbar-text' eventKey='7'>Data</Nav.Link>
-      <Nav.Link as={NavLink} activeClassName='active-navlink' to='/MetriqGym' className='metriq-navbar-text' eventKey='8'>metriq-gym <span role="img" aria-label="new">🆕</span></Nav.Link>
+      <Nav.Link
+        as={NavLink}
+        activeClassName='active-navlink'
+        to='/MetriqGym'
+        className='metriq-navbar-text'
+        eventKey='8'
+      >
+        metriq-gym<span style={{ fontSize: '0.7em', color: '#888', marginLeft: 2, verticalAlign: 'super' }}>Beta</span>
+      </Nav.Link>
     </Nav>
   )
 }

--- a/src/components/MainNavLeft.js
+++ b/src/components/MainNavLeft.js
@@ -14,6 +14,7 @@ const MainNavLeft = () => {
       <Nav.Link as={NavLink} activeClassName='active-navlink' to='/Trends' className='metriq-navbar-text' eventKey='5' isActive={(match, location) => (location.pathname === '/Trends' || location.pathname === '/')}>Trends</Nav.Link>
       <Nav.Link as={NavLink} activeClassName='active-navlink' to='/Progress' className='metriq-navbar-text' eventKey='6'>Progress</Nav.Link>
       <Nav.Link as={NavLink} activeClassName='active-navlink' to='/Data' className='metriq-navbar-text' eventKey='7'>Data</Nav.Link>
+      <Nav.Link as={NavLink} activeClassName='active-navlink' to='/MetriqGym' className='metriq-navbar-text' eventKey='8'>metriq-gym <span role="img" aria-label="new">🆕</span></Nav.Link>
     </Nav>
   )
 }

--- a/src/views/MetriqGym.js
+++ b/src/views/MetriqGym.js
@@ -64,7 +64,7 @@ class MetriqGym extends React.Component {
 }
         return (            
             <div id='metriq-main-content' className='container'>
-              <h3 align='left'><a href={`/submission/${METRIQ_GYM_SUBMISSION_ID}`}>metriq-gym results</a></h3>
+              <h3 style={{ textAlign: "left" }}><a href={`/submission/${METRIQ_GYM_SUBMISSION_ID}`}>metriq-gym results</a></h3>
                 <p
                     style={{
                         textAlign: "left",

--- a/src/views/MetriqGym.js
+++ b/src/views/MetriqGym.js
@@ -9,13 +9,13 @@ import AggregatedMetricsTable from '../components/AggregatedMetricsTable'
 const METRIQ_GYM_SUBMISSION_ID = 800
 
 class MetriqGym extends React.Component {
+
     constructor (props) {
         super(props)
         this.state = {
             isLoading: true,
-            results: [],
             requestFailedMessage: '',
-            isLinkBlocked: false
+            results: [],
         }
     }
 
@@ -47,13 +47,41 @@ class MetriqGym extends React.Component {
     }
 
     render () {
-        return (
+        const { isLoading, requestFailedMessage, results } = this.state;
+        if (isLoading) {
+            return (
+                <div id='metriq-main-content' className='container'>
+                    <p>Loading...</p>
+                </div>
+            );
+        }
+        if (requestFailedMessage) {
+            return (
+                <div id='metriq-main-content' className='container'>
+                    <p>Error: {requestFailedMessage}</p>
+                </div>
+            );
+}
+        return (            
             <div id='metriq-main-content' className='container'>
-                <h4 align='left'><a href={`/submission/${METRIQ_GYM_SUBMISSION_ID}`}>Metriq-gym results</a></h4>
-                <br />
-                <AggregatedMetricsTable results={this.state.results} />
+              <h3 align='left'><a href={`/submission/${METRIQ_GYM_SUBMISSION_ID}`}>metriq-gym results</a></h3>
+                <p
+                    style={{
+                        textAlign: "left",
+                        maxWidth: "680px",
+                        fontSize: "1.15rem",
+                        lineHeight: 1.7,
+                        padding: "24px 32px",
+                        margin: "32px 0",
+                        display: "block"
+                    }}
+                >
+                  Benchmark results in this page are collected using the <a href='https://github.com/unitaryfoundation/metriq-gym'>metriq-gym</a> toolkit.
+                  They are run by the Unitary Foundation team on a variety of platforms.
+                </p>
+              <br />
+              <AggregatedMetricsTable results={results} />
             </div>
-
         )
     }
 }

--- a/src/views/MetriqGym.js
+++ b/src/views/MetriqGym.js
@@ -76,7 +76,7 @@ class MetriqGym extends React.Component {
                         display: "block"
                     }}
                 >
-                  Benchmark results in this page are collected using the <a href='https://github.com/unitaryfoundation/metriq-gym'>metriq-gym</a> toolkit.
+                  Benchmark results in this page are collected using the <a href='https://github.com/unitaryfoundation/metriq-gym' target="_blank" rel="noopener noreferrer">metriq-gym</a> toolkit.
                   They are run by the Unitary Foundation team on a variety of platforms.
                 </p>
               <br />

--- a/src/views/MetriqGym.js
+++ b/src/views/MetriqGym.js
@@ -1,0 +1,61 @@
+import axios from 'axios'
+import React from 'react'
+import config from '../config'
+import { withRouter } from 'react-router-dom'
+import ErrorHandler from '../components/ErrorHandler'
+
+import AggregatedMetricsTable from '../components/AggregatedMetricsTable'
+
+const METRIQ_GYM_SUBMISSION_ID = 800
+
+class MetriqGym extends React.Component {
+    constructor (props) {
+        super(props)
+        this.state = {
+            isLoading: true,
+            results: [],
+            requestFailedMessage: '',
+            isLinkBlocked: false
+        }
+    }
+
+    componentDidMount () {
+        axios.get(`${config.api.getUriPrefix()}/submission/${METRIQ_GYM_SUBMISSION_ID}/results`)
+            .then(async res => {
+                const results = res.data.data || []
+                const platformIds = [...new Set(results.map(r => r.platformId).filter(Boolean))]
+                const platformResponses = await Promise.all(
+                platformIds.map(id =>
+                    axios.get(`${config.api.getUriPrefix()}/platform/${id}`)
+                    .then(res => ({ id, data: res.data.data }))
+                    .catch(() => ({ id, data: null }))
+                )
+                )
+                const platformMap = {}
+                platformResponses.forEach(({ id, data }) => {
+                platformMap[id] = data
+                })
+                const enrichedResults = results.map(r => ({
+                ...r,
+                platform: platformMap[r.platformId] || {}
+                }))
+                this.setState({ results: enrichedResults, isLoading: false })
+            })
+            .catch(err => {
+                this.setState({ requestFailedMessage: ErrorHandler(err), isLoading: false })
+            })
+    }
+
+    render () {
+        return (
+            <div id='metriq-main-content' className='container'>
+                <h4 align='left'><a href={`/submission/${METRIQ_GYM_SUBMISSION_ID}`}>Metriq-gym results</a></h4>
+                <br />
+                <AggregatedMetricsTable results={this.state.results} />
+            </div>
+
+        )
+    }
+}
+
+export default withRouter(MetriqGym)

--- a/src/views/Trends.js
+++ b/src/views/Trends.js
@@ -9,11 +9,8 @@ import ErrorHandler from '../components/ErrorHandler'
 import FormFieldValidator from '../components/FormFieldValidator'
 import FormFieldAlertRow from '../components/FormFieldAlertRow'
 import QuantumVolumeChart from '../components/QuantumVolumeChart'
-import AggregatedMetricsTable from '../components/AggregatedMetricsTable'
 
 library.add(faHeart, faExternalLinkAlt, faChartLine)
-
-const METRIQ_GYM_SUBMISSION_ID = 800
 
 class Trends extends React.Component {
   constructor (props) {
@@ -52,31 +49,6 @@ class Trends extends React.Component {
   }
 
   componentDidMount () {
-    axios.get(`${config.api.getUriPrefix()}/submission/${METRIQ_GYM_SUBMISSION_ID}/results`)
-      .then(async res => {
-        const results = res.data.data || []
-        const platformIds = [...new Set(results.map(r => r.platformId).filter(Boolean))]
-        const platformResponses = await Promise.all(
-          platformIds.map(id =>
-            axios.get(`${config.api.getUriPrefix()}/platform/${id}`)
-              .then(res => ({ id, data: res.data.data }))
-              .catch(() => ({ id, data: null }))
-          )
-        )
-        const platformMap = {}
-        platformResponses.forEach(({ id, data }) => {
-          platformMap[id] = data
-        })
-        const enrichedResults = results.map(r => ({
-          ...r,
-          platform: platformMap[r.platformId] || {}
-        }))
-        this.setState({ results: enrichedResults, isLoading: false })
-      })
-      .catch(err => {
-        this.setState({ requestFailedMessage: ErrorHandler(err), isLoading: false })
-      })
-
     axios.get(config.api.getUriPrefix() + '/task/submissionCount')
       .then(res => {
         const alphabetical = res.data.data
@@ -152,13 +124,6 @@ class Trends extends React.Component {
                   <br />
                 </span>
               )}
-            </div>
-          </div>
-          <div className='row'>
-            <div className='col'>
-              <h4 align='left'><a href={`/submission/${METRIQ_GYM_SUBMISSION_ID}`}>Metriq-gym results</a></h4>
-              <br />
-              <AggregatedMetricsTable results={this.state.results} />
             </div>
           </div>
           <br />


### PR DESCRIPTION
Simple redesign, moving the metriq-gym table to a new page with a dedicated tab link in the navigation bar.

![Screenshot 2025-07-07 at 15 50 49](https://github.com/user-attachments/assets/c803a9f6-9b65-4b4f-bc54-654a5fadb684)
