### PR TITLE
fix: item can be added properly now under task

### DIFF
--- a/src/components/SubmissionRefsAddModal.js
+++ b/src/components/SubmissionRefsAddModal.js
@@ -153,7 +153,7 @@ const SubmissionRefsAddModal = (props) => {
     const itemCopy = { ...item }
     itemCopy.id = nItem.id
     setItem(itemCopy)
-    handleValidation(item)
+    handleValidation(itemCopy)
   }
 
   const handleOnChangeRef = (key, value) => {

--- a/src/components/SubmissionRefsAddModal.js
+++ b/src/components/SubmissionRefsAddModal.js
@@ -128,20 +128,19 @@ const SubmissionRefsAddModal = (props) => {
       return
     }
 
-    const fn = props.allNames.find(f => f.name === value)
     const itemCopy = { ...item }
+    const fn = props.allNames.find(f => f.name === value)
     if (fn) {
       itemCopy.parent = fn.id
-      handleValidation(itemCopy)
     } else {
       itemCopy.parent = 0
-      if (value) {
-        setIsValid(false)
-      } else {
-        handleValidation(itemCopy)
-      }
     }
     setItem(itemCopy)
+    if (fn || !value) {
+      handleValidation(itemCopy)
+    } else {
+      setIsValid(false)
+    }
   }
 
   const handleOnSelectRef = (nItem) => {


### PR DESCRIPTION
When selecting an item under the "Add Task" modal (or any of the other modals in fact), the first item that is selected enables the "Submit" button (whereas before, this would have to be clicked twice to do so). 